### PR TITLE
Add ship, file, and clear motto to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 My personal Claude Code statusline configuration — versioned and maintained here so I have a history of changes and a single place to make updates.
 
 This repo is public as a reference. I'm the only one making changes.
+
+---
+
+*Ship, file, and clear.*


### PR DESCRIPTION
Adds the repo motto to the README as a closing line. Came up naturally during the first session — felt right to capture it.
