### PR TITLE
Fix branch display: show true name and indicate uncommitted changes

### DIFF
--- a/statusline-command.sh
+++ b/statusline-command.sh
@@ -35,16 +35,15 @@ RESET='\033[0m'
 
 branch=""
 ahead=""
+dirty=""
 if [ -n "$cwd" ] && git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
-  raw_branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null)
-  if [ "$raw_branch" = "main" ]; then
-    branch="engine"
-  else
-    branch="${raw_branch#project/}"
-  fi
+  branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null)
   ahead_count=$(git -C "$cwd" rev-list --no-walk=unsorted --count "origin/HEAD..HEAD" 2>/dev/null)
   if [ -n "$ahead_count" ] && [ "$ahead_count" -gt 0 ] 2>/dev/null; then
     ahead="+${ahead_count}"
+  fi
+  if [ -n "$(git -C "$cwd" status --porcelain 2>/dev/null)" ]; then
+    dirty="*"
   fi
 fi
 
@@ -87,8 +86,12 @@ fi
 
 status=""
 if [ -n "$branch" ]; then
-  if [ -n "$ahead" ]; then
+  if [ -n "$ahead" ] && [ -n "$dirty" ]; then
+    status="${CYAN}(${branch}${YELLOW}${dirty} ${ahead}${CYAN})${RESET}"
+  elif [ -n "$ahead" ]; then
     status="${CYAN}(${branch} ${YELLOW}${ahead}${CYAN})${RESET}"
+  elif [ -n "$dirty" ]; then
+    status="${CYAN}(${branch}${YELLOW}${dirty}${CYAN})${RESET}"
   else
     status="${CYAN}(${branch})${RESET}"
   fi


### PR DESCRIPTION
## Summary

Fixes branch display by removing the hardcoded `engine` alias for `main` and the `project/` prefix strip, so the actual branch name is always shown. Adds a yellow `*` dirty indicator that appears when the working tree has uncommitted changes.

## Changes

- Removed `main` → `engine` alias and `project/` prefix strip — branch name is now taken directly from `git symbolic-ref --short HEAD` with no transformation
- Added `dirty` detection via `git status --porcelain` — appended as a yellow `*` suffix on the branch name when the working tree is unclean
- Updated branch display to handle four states: clean, dirty-only, ahead-only, and dirty+ahead

## Test plan

- [ ] Run statusline with a dirty working tree — verify `(branchname*)` with yellow `*`
- [ ] Run on `main` with clean tree — verify `(main)` not `(engine)`

## Issue

Closes #7

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
