### PR TITLE
Link github-weld repo in README workflow section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ My personal Claude Code statusline configuration — versioned and maintained he
 
 This repo is public as a reference. I'm the only one making changes.
 
+## Workflow
+
+Changes go through [github-weld](https://github.com/WrathZA/github-weld) — structured issues, correctly-named branches, and a session export at every merge commit. For a repo that's just one config file, that might seem like overkill — but the point is the audit trail. Each PR captures *why* a change was made, not just what changed.
+
 ---
 
 *Ship, file, and clear.*


### PR DESCRIPTION
## Summary

Added a Workflow section to README that links directly to `WrathZA/github-weld` using the repo's own stated description. The earlier draft had no link and paraphrased the tool's purpose; this replaces it with the repo's words and a live link.

## Changes

- `README.md` — new `## Workflow` section with a link to `https://github.com/WrathZA/github-weld` and description sourced from the repo itself rather than written by hand

## Test plan

- [ ] Open README and confirm the Workflow section contains a working link to `https://github.com/WrathZA/github-weld`

## Issue

Closes #9

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
