### PR TITLE
Add sandbox.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+sandbox.md
 settings.local.json
 .weld/tmp/


### PR DESCRIPTION
## Summary

Adds `sandbox.md` to `.gitignore` so scratch files used during exploration sessions don't get accidentally committed to the repo.

## Changes

- Added `sandbox.md` to `.gitignore` — keeps the working tree clean without requiring deletion of scratch files between sessions

## Test plan

- [ ] Create a `sandbox.md` file in the repo root; run `git status` — it should not appear as untracked

## Issue

Closes #11

---
*Created with [gh-weld](https://github.com/WrathZA/github-weld)*
